### PR TITLE
Add kaas metric importer and document local deployment

### DIFF
--- a/mvp-0/README.md
+++ b/mvp-0/README.md
@@ -1,10 +1,12 @@
 # MVP-0
 
-## Observer cluster
+## Deployment
 
-### Deploy dnation-kubernetes-monitoring-stack without dnation-kubernetes-monitoring
+### Observer cluster
 
-1. Fill `thanos-storage.yaml` with bucket credentials
+#### Deploy dnation-kubernetes-monitoring-stack without dnation-kubernetes-monitoring
+
+1. Optional: Fill `thanos-storage.yaml` with bucket credentials in **thanosStorage config**
 2. Deploy
    ```bash
    helm repo add dnationcloud https://dnationcloud.github.io/helm-hub/
@@ -12,10 +14,10 @@
    helm upgrade --install dnation-kubernetes-monitoring-stack dnationcloud/dnation-kubernetes-monitoring-stack \
      --set dnation-kubernetes-monitoring.enabled=false \
      -f values-observer.yaml \
-     -f thanos-storage.yaml
+     -f thanos-storage.yaml # Optional
    ```
 
-### Deploy dnation-kubernetes-monitoring
+#### Deploy dnation-kubernetes-monitoring
 
 1. Clone and build rules/dashboards
    ```bash
@@ -32,15 +34,26 @@
      -f values-observer-dash.yaml
    ```
 
-## Workload cluster
+#### Deploy kaas-metric-importer
 
-### Create KinD workload cluster
-
-```bash
-kind create cluster --config kind_cluster_config.yaml --image kindest/node:v1.25.11 --name workload
+Deployment uses an image built from https://github.com/m3dbx/prometheus_remote_client_golang.
+It has mounted configmap and based on configmap keys it pushes custom metric `kaas`
+with label `cluster` and value `1` into thanos receiver.
+E.g. configmap:
+```yaml
+data:
+  workload-cluster: ""
 ```
+It pushes metric `kaas{cluster="workload-cluster"} 1`.
 
-### Deploy prometheus agent
+1. Deploy
+   ```bash
+   kubectl apply -f kaas-metric-importer.yaml
+   ```
+
+### Workload cluster
+
+#### Deploy prometheus agent
 
 1. Fill `values-workload.yaml` **remoteWrite url**
 2. Deploy
@@ -50,3 +63,44 @@ kind create cluster --config kind_cluster_config.yaml --image kindest/node:v1.25
    helm upgrade --install monitoring prometheus-community/kube-prometheus-stack \
      -f values-workload.yaml
    ```
+
+#### Patch kaas-clusters configmap in the observer cluster
+
+1. Take **externalLabels cluster** from `values-workload.yaml`
+2. Patch
+   ```bash
+   kubectl patch cm kaas-clusters -p '{"data":{"workload-cluster":""}}'
+   ```
+
+## Quick local deployment
+
+### Observer
+Create observer cluster in KinD, see [Observer cluster](#observer-cluster) for more.
+
+Run:
+```bash
+kind create cluster --config kind_cluster_config.yaml --image kindest/node:v1.25.11 --name observer
+
+helm --kube-context kind-observer upgrade --install dnation-kubernetes-monitoring-stack dnationcloud/dnation-kubernetes-monitoring-stack \
+  --set dnation-kubernetes-monitoring.enabled=false \
+  -f values-observer.yaml
+
+helm --kube-context kind-observer upgrade --install dnation-kubernetes-monitoring kubernetes-monitoring/chart \
+  --set releaseOverride=dnation-kubernetes-monitoring-stack \
+  -f values-observer-dash.yaml
+
+kubectl --context kind-observer apply -f kaas-metric-importer.yaml
+```
+
+### Workload
+Create workload cluster in KinD, see [Workload cluster](#workload-cluster) for more.
+
+Fill `values-workload.yaml` **remoteWrite url** with *http://observer-control-plane:30291/api/v1/receive* and run:
+```bash
+kind create cluster --config kind_cluster_config.yaml --image kindest/node:v1.25.11 --name workload
+
+helm --kube-context kind-workload upgrade --install monitoring prometheus-community/kube-prometheus-stack \
+  -f values-workload.yaml
+
+kubectl --context kind-observer patch cm kaas-clusters -p '{"data":{"workload-cluster":""}}'
+```

--- a/mvp-0/kaas-metric-importer.yaml
+++ b/mvp-0/kaas-metric-importer.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kaas-clusters
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kaas-metric-importer
+  labels:
+    app: kaas-metric-importer
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kaas-metric-importer
+  template:
+    metadata:
+      labels:
+        app: kaas-metric-importer
+    spec:
+      containers:
+      - name: kaas-metric-importer
+        # https://github.com/m3dbx/prometheus_remote_client_golang/blob/master/Dockerfile
+        image: registry.dnation.cloud/library/promremote
+        command: ["/bin/sh"]
+        args:
+        - -c
+        - |
+          while true
+          do
+            for FILE in $(find -L /clusters -maxdepth 1 -type f)
+            do
+              promremotecli -u http://thanos-receive:19291/api/v1/receive -t=__name__:kaas -t=cluster:$(basename $FILE) -d=now,1
+            done
+            sleep 10
+          done
+        volumeMounts:
+        - name: clusters
+          mountPath: "/clusters"
+          readOnly: true
+      volumes:
+      - name: clusters
+        configMap:
+          name: kaas-clusters

--- a/mvp-0/thanos-storage.yaml
+++ b/mvp-0/thanos-storage.yaml
@@ -1,4 +1,7 @@
 thanosStorage:
+  secret:
+    name: thanos-objstore-config
+    key: objstore.yml
   config: |-
    type: S3
    config:
@@ -6,3 +9,21 @@ thanosStorage:
      bucket: "<observer-bucket-name>"
      access_key: "<access-key>"
      secret_key: "<secret-key>"
+
+thanos:
+  existingObjstoreSecret: thanos-objstore-config
+  storegateway:
+    enabled: true
+
+kube-prometheus-stack:
+  prometheus:
+    prometheusSpec:
+      thanos:
+        objectStorageConfig:
+          name: thanos-objstore-config
+          key: objstore.yml
+  thanosRuler:
+    thanosRulerSpec:
+      objectStorageConfig:
+        name: thanos-objstore-config
+        key: objstore.yml

--- a/mvp-0/values-observer-dash.yaml
+++ b/mvp-0/values-observer-dash.yaml
@@ -1,5 +1,6 @@
 grafanaDashboards:
   isLoki: false
 prometheusRules:
+  enable: false
   labelPrometheus:
     prometheus_rule: '2'

--- a/mvp-0/values-observer.yaml
+++ b/mvp-0/values-observer.yaml
@@ -1,14 +1,5 @@
-thanosStorage:
-  secret:
-    name: thanos-objstore-config
-    key: objstore.yml
-  config: ""
-
 thanos:
   fullnameOverride: thanos
-  existingObjstoreSecret: thanos-objstore-config
-  storegateway:
-    enabled: true
   query:
     replicaLabel: [agent_replica, sidecar_replica]
     stores:
@@ -24,11 +15,11 @@ thanos:
 
 grafanaDatasourcesAsConfigMap:
   cluster-metrics:
-    - name: thanos
-      isDefault: true
-      type: prometheus
-      access: proxy
-      url: http://thanos-query:9090
+  - name: thanos
+    isDefault: true
+    type: prometheus
+    access: proxy
+    url: http://thanos-query:9090
   cluster-logs: null
 loki:
   enabled: false
@@ -52,13 +43,30 @@ kube-prometheus-stack:
       replicaExternalLabelName: sidecar_replica
       externalLabels:
         cluster: observer-cluster
-      thanos:
-        objectStorageConfig:
-          name: thanos-objstore-config
-          key: objstore.yml
   defaultRules:
+    create: false
     labels:
       prometheus_rule: '2'
+  additionalPrometheusRulesMap:
+    dnation-kubernetes-monitoring-rules:
+      additionalLabels:
+        prometheus_rule: '2'
+      groups:
+      - name: k8s.rules
+        rules:
+        - alert: KubernetesMonitoringClusterDown
+          expr: 'kaas unless on(cluster) up'
+          for: 5m
+          labels:
+            alertgroup: Cluster
+            severity: critical
+          annotations:
+            message: 'Cluster {{ $labels.cluster }} is down.'
+        # add recording rules manually as prometheusRules are disabled in values-observer-dash.yaml
+        - record: 'master_uname_info'
+          expr: 'node_uname_info{job=~"node-exporter"} and on(nodename) label_replace(kube_node_role{role=~"control-plane"}, "nodename", "$1", "node", "(.+)")'
+        - record: 'worker_uname_info'
+          expr: 'node_uname_info{job=~"node-exporter"} unless on(nodename) label_replace(kube_node_role{role=~"control-plane"}, "nodename", "$1", "node", "(.+)")'
   nameOverride: kube-prometheus
   thanosRuler:
     enabled: true
@@ -69,9 +77,6 @@ kube-prometheus-stack:
         protocol: TCP
         targetPort: 10901
     thanosRulerSpec:
-      objectStorageConfig:
-        name: thanos-objstore-config
-        key: objstore.yml
       ruleSelector:
         matchLabels:
           prometheus_rule: '2'


### PR DESCRIPTION
Also, disable default rules and make thanos storage optional

Related to epic SovereignCloudStack/issues#291, issues SovereignCloudStack/issues#302 and SovereignCloudStack/issues#303