### PR TITLE
Enable default kube-prometheus-stack rules

### DIFF
--- a/mvp-0/values-observer.yaml
+++ b/mvp-0/values-observer.yaml
@@ -59,7 +59,6 @@ kube-prometheus-stack:
       externalLabels:
         cluster: observer-cluster
   defaultRules:
-    create: false
     labels:
       prometheus_rule: '2'
   additionalPrometheusRulesMap:


### PR DESCRIPTION
Related to SovereignCloudStack/issues#303