### PR TITLE
Add query lookback-delta flag

### DIFF
--- a/mvp-0/values-observer.yaml
+++ b/mvp-0/values-observer.yaml
@@ -15,6 +15,7 @@ thanos:
   query:
     extraFlags:
     - --query.auto-downsampling
+    - --query.lookback-delta=1m
     replicaLabel: [agent_replica, sidecar_replica]
     stores:
     - dnssrv+_grpc._tcp.kube-prometheus-thanos-ruler


### PR DESCRIPTION
By default, it is 5m. According to the [Thanos querier docs](https://thanos.io/tip/components/query.md/), it should be set to at least 2 times of the slowest scrape interval, which is 30s for us.