### PR TITLE
Fix thanos fullname

### DIFF
--- a/registry/workload/values-workload.yaml
+++ b/registry/workload/values-workload.yaml
@@ -1,4 +1,5 @@
 thanos:
+  fullnameOverride: thanos
   query:
     replicaCount: 2
     replicaLabel: [prometheus_replica]


### PR DESCRIPTION
The store gateway had an error:
create Pod dnation-kubernetes-monitoring-stack-thanos-storegateway-0 in StatefulSet dnation-kubernetes-monitoring-stack-thanos-storegateway failed error: Pod "dnation-kubernetes-monitoring-stack-thanos-storegateway-0" is invalid: [metadata.labels: Invalid value: "dnation-kubernetes-monitoring-stack-thanos-storegateway-5968dd568f": must be no more than 63 characters, spec.subdomain: Invalid value: "dnation-kubernetes-monitoring-stack-thanos-storegateway-headless": must be no more than 63 characters]