### PR TITLE
Increase thanos compactor pvc for registry workload cluster

### DIFF
--- a/registry/workload/thanos-objstore.yaml
+++ b/registry/workload/thanos-objstore.yaml
@@ -18,6 +18,8 @@ thanos:
     enabled: true
   compactor:
     enabled: true
+    persistence:
+      size: 20Gi
 
 kube-prometheus-stack:
   prometheus:


### PR DESCRIPTION
Default size 8Gi was used and it was full on 98% - alert `KubernetesMonitoringPVCUtilizationHigh` was firing