### PR TITLE
Enable grafana explore feature for the anonymous access

### DIFF
--- a/values-observer-scs.yaml
+++ b/values-observer-scs.yaml
@@ -212,6 +212,7 @@ kube-prometheus-stack:
 ## Uncomment if you want to allow anonymous access to the UI (Grafana)
     env:
       GF_AUTH_ANONYMOUS_ENABLED: true
+      GF_USERS_VIEWERS_CAN_EDIT: true
 ## Uncomment if you want to apply a custom SCS branding
     extraConfigmapMounts:
       - name: scs-logo


### PR DESCRIPTION
This PR enables grafana explore feature for the anonymous access. Now anonymous users are able to view the logs too.

Fixes #63 